### PR TITLE
Fixing invalid "main" value for package.json: should be "lib/index.js"

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-file-picker",
   "version": "0.0.5",
   "description": "A simple wrapper around the native file input",
-  "main": "index.js",
+  "main": "lib/index.js",
   "module": "lib/index.js",
   "scripts": {
     "build": "webpack --config config/webpack.js",


### PR DESCRIPTION
This is a fix for issue https://github.com/meinstein/react-file-picker/issues/6