### PR TITLE
Add file input 'accept' attribute

### DIFF
--- a/src/FileInput/index.js
+++ b/src/FileInput/index.js
@@ -21,7 +21,7 @@ class FileInput extends React.Component {
     return (
       <div style={this.props.style}>
         <input
-          accept={accept}
+          accept={this.props.accept}
           type="file"
           style={{ display: 'none' }}
           onChange={this._handleUpload}

--- a/src/FileInput/index.js
+++ b/src/FileInput/index.js
@@ -21,6 +21,7 @@ class FileInput extends React.Component {
     return (
       <div style={this.props.style}>
         <input
+          accept={accept}
           type="file"
           style={{ display: 'none' }}
           onChange={this._handleUpload}
@@ -36,6 +37,7 @@ class FileInput extends React.Component {
 
 FileInput.propTypes = {
   style: PropTypes.object,
+  accept: PropTypes.string,
   children: PropTypes.node.isRequired,
   onChange: PropTypes.func.isRequired
 }

--- a/src/FilePicker/index.js
+++ b/src/FilePicker/index.js
@@ -49,10 +49,11 @@ class FilePicker extends React.Component {
   }
 
   render() {
-    const { children, style } = this.props
+    const { children, style } = this.props;
+    const accept = this.props.extensions.map(ext => `.${ext}`).join(',')
 
     return (
-      <FileInput onChange={this._validate} style={style}>
+      <FileInput onChange={this._validate} style={style} accept={accept}>
         {children}
       </FileInput>
     )


### PR DESCRIPTION
Used the existing extensions prop to build a string of acceptable file extensions for the file input component.